### PR TITLE
感情アラート機能の実装

### DIFF
--- a/emotion_analysis.py
+++ b/emotion_analysis.py
@@ -1,0 +1,108 @@
+## emotion_analysis.py
+import logging
+from google.cloud import language_v1
+from langchain_core.output_parsers import JsonOutputParser
+from langchain.prompts import PromptTemplate
+from conversation_chain import llm
+
+logging.basicConfig(level=logging.INFO)
+
+# 1. ユーザー発言のみ抽出（JsonOutputParser使用）
+def extract_partner_mentions_llm(chat_history: str, partner_name: str = None) -> list:
+    parser = JsonOutputParser()
+    if partner_name:
+        instruction = (
+            f"以下の会話履歴から、ユーザーによるパートナー（{partner_name}）に関する発言のみを、"
+            "原文そのままで抽出してください。"
+        )
+    else:
+        instruction = (
+            "以下の会話履歴から、ユーザーがパートナーに言及した発言だけを、"
+            "原文のままで抽出してください。"
+        )
+    prompt_template = PromptTemplate.from_template(
+        instruction +
+        "\n抽出対象は**ユーザーの発言のみ**で、コーチの発言は含めないでください。"
+        "\n出力は**文字列のJSONリスト**として、余計な説明や装飾を含めず返してください。"
+        "\n{format_instructions}\n\n会話履歴:\n{chat_history}"
+    )
+    prompt = prompt_template.format(
+        chat_history=chat_history,
+        format_instructions=parser.get_format_instructions()
+    )
+    logging.info("パートナーへの言及部分をLLMで抽出中")
+    try:
+        result = llm.invoke(prompt)
+        if hasattr(result, "content"):
+            result = result.content
+        logging.debug(f"LLM raw output:\n{result}")
+        mentions = parser.parse(result)
+        if not isinstance(mentions, list):
+            raise ValueError("抽出結果がリスト形式ではありません")
+        return mentions
+    except Exception as e:
+        logging.error("LLM抽出中にエラーが発生しました: " + str(e))
+        return []
+
+# 2. 感情分析（Google NLP）
+def analyze_sentiment(text: str):
+    client = language_v1.LanguageServiceClient()
+    document = language_v1.Document(content=text, type_=language_v1.Document.Type.PLAIN_TEXT)
+    response = client.analyze_sentiment(document=document)
+    sentiment = response.document_sentiment
+    return sentiment.score, sentiment.magnitude
+
+# 3. 発言全体の感情を集約して5段階に分類する
+def classify_partner_emotion(mentions: list) -> dict:
+    """
+    複数の発言に対して感情分析を実施し、各発言のスコアと強度の重み付き平均（avg_score）と、
+    全発言中の最大感情強度（max_magnitude）を求めた上で、パートナーの感情状態を5段階に分類する。
+    戻り値は、集約した平均スコア、最大感情強度、およびラベル、絵文字、定型アラートメッセージを含む dict。
+    """
+    total_weight = 0.0
+    weighted_score_sum = 0.0
+    max_magnitude = 0.0
+    for mention in mentions:
+        score, magnitude = analyze_sentiment(mention)
+        weighted_score_sum += score * magnitude
+        total_weight += magnitude
+        if magnitude > max_magnitude:
+            max_magnitude = magnitude
+    avg_score = weighted_score_sum / total_weight if total_weight else 0.0
+
+    # 5段階分類の条件
+    if avg_score < -0.6 and max_magnitude > 2.0:
+        alert = {
+            "label": "激おこ",
+            "emoji": "😡",
+            "message": "相手がブチギレ寸前です。慎重に話しかけてください。"
+        }
+    elif avg_score < -0.5:
+        alert = {
+            "label": "情緒が乱れている",
+            "emoji": "😠",
+            "message": "不満や苛立ち、悲しみなど強めの感情があるかもしれません。丁寧なコミュニケーションを。"
+        }
+    elif avg_score < -0.4:
+        alert = {
+            "label": "モヤモヤ・落ち込み気味",
+            "emoji": "😟",
+            "message": "怒りというより、少し気持ちが落ちているかもしれません。静かに寄り添ってみましょう。"
+        }
+    elif avg_score < -0.2:
+        alert = {
+            "label": "小さな違和感",
+            "emoji": "😐",
+            "message": "少しだけ引っかかることがあるかも。気にかけてあげるといいかも。"
+        }
+    else:
+        alert = {
+            "label": "安定・ご機嫌",
+            "emoji": "😊",
+            "message": "相手はご機嫌な様子。気持ちよくコミュニケーションが取れそうです！"
+        }
+    return {
+        "average_score": avg_score,
+        "max_magnitude": max_magnitude,
+        **alert
+    }

--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 ### models.py ###
 import enum
-from sqlalchemy import Column, String, Date, Integer, DateTime, Text, Enum, ForeignKey
+from sqlalchemy import Column, String, Date, Integer, DateTime, Text, Float, Enum, ForeignKey
 from datetime import datetime
 from db import Base
 
@@ -55,4 +55,26 @@ class VectorSummary(Base):
     user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)
     query_key = Column(Text, nullable=False)
     summary_text = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+class EmotionAlert(Base):
+    __tablename__ = "emotion_alerts"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    # このアラートがどの会話履歴に紐付くか
+    conversation_history_id = Column(Integer, ForeignKey("conversation_history.id"), nullable=False)
+    # アラートを受信するパートナーのユーザーID
+    user_id = Column(Integer, ForeignKey("users.user_id"), nullable=False)
+    # アラート対象の最もネガティブな発言
+    most_negative_mention = Column(Text, nullable=False)
+    # 感情スコア (-1.0 ~ +1.0)
+    score = Column(Float, nullable=False)
+    # 感情の強度（0以上の値）
+    magnitude = Column(Float, nullable=False)
+    # 固定の定型テキストで決まった感情ラベル（例："激おこ", "情緒が乱れている" など）
+    label = Column(String(50), nullable=False)
+    # 絵文字で表す、あるいは短いラベル（例："😡"など）
+    emoji = Column(String(10), nullable=False)
+    # 定型のアラート文
+    message = Column(Text, nullable=False)
+    # 生成日時（何日前の感情かを示すため）
     created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## 概要
感情アラート機能の実装（会話履歴からパートナーに関するネガティブ発言を抽出し、感情スコアを判定してDBに保存）

## 主な変更点
- `emotion_analysis.py`：LLMとGoogle NLPによる感情抽出・分類処理
- `main.py`：`/save_conversation`に感情分析ロジックを統合
- `models.py`：`EmotionAlert` モデル追加

## 備考
- 機能単位で動作確認済み
