### PR TITLE
感情アラート保存時のuser_id型不一致の修正とGCP認証ファイル名統一

### DIFF
--- a/emotion_analysis.py
+++ b/emotion_analysis.py
@@ -35,7 +35,7 @@ def extract_partner_mentions_llm(chat_history: str, partner_name: str = None) ->
         result = llm.invoke(prompt)
         if hasattr(result, "content"):
             result = result.content
-        logging.debug(f"LLM raw output:\n{result}")
+        logging.info(f"LLM raw output:\n{result}")
         mentions = parser.parse(result)
         if not isinstance(mentions, list):
             raise ValueError("抽出結果がリスト形式ではありません")

--- a/main.py
+++ b/main.py
@@ -144,7 +144,7 @@ async def chat_endpoint(request: ChatRequest):
         db.close()
 
 @app.post("/save_conversation")
-async def save_conversation(session_id: str, user_id: str):
+async def save_conversation(session_id: str, user_id: int):
     db = SessionLocal()
     try:
         # セッションの存在確認
@@ -211,6 +211,7 @@ async def save_conversation(session_id: str, user_id: str):
         }    
     
     except Exception as e:
+        logger.exception("エラー内容:")
         db.rollback()
         raise HTTPException(status_code=500, detail="保存中にエラーが発生しました")
     finally:


### PR DESCRIPTION
- EmotionAlert保存時のuser_idの型不一致（str→int）によるエラーを修正

## 修正ファイル
- main.py
- emotion_analysis.py
